### PR TITLE
Fix SingularMatrix exception

### DIFF
--- a/U3-M3-baseline.ipynb
+++ b/U3-M3-baseline.ipynb
@@ -372,7 +372,7 @@
    ],
    "source": [
     "sample_df = df.sample(n=100, random_state=42)\n",
-    "sns.pairplot(sample_df, hue=\"group\", palette={0: '#AA4444', 1: '#006000', 2: '#EEEE44'})"
+    "sns.pairplot(sample_df, hue=\"group\",kind="scatter", diag_kind="histogram", palette={0: '#AA4444', 1: '#006000', 2: '#EEEE44'})"
    ]
   },
   {


### PR DESCRIPTION
Looks like omitting `kind="scatter",diag_kind="histogram"` from pairplot signature causes SingularMatrix exception